### PR TITLE
more portable way of specifying python version

### DIFF
--- a/linux_clicky/detect_keyboards.py
+++ b/linux_clicky/detect_keyboards.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- Mode: Python; coding: utf-8; indent-tabs-mode: nil; tab-width: 2 -*-
 # Author: Fábio André Damas <skkeeper at gmail dot com>
 

--- a/linux_clicky/play_sound.py
+++ b/linux_clicky/play_sound.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- Mode: Python; coding: utf-8; indent-tabs-mode: nil; tab-width: 2 -*-
 # Author: Fábio André Damas <skkeeper at gmail dot com>
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # -*- Mode: Python; coding: utf-8; indent-tabs-mode: nil; tab-width: 2 -*-
 # Author: Fábio André Damas <skkeeper at gmail dot com>
 

--- a/third_party/evdev.py
+++ b/third_party/evdev.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """ evdev.py
 


### PR DESCRIPTION
`/usr/bin/python` points to python3 in ArchLinux and `/usr/bin/env python`
uses python3 by default.

`/usr/bin/env python2` will point to correct python in all old and new systems
